### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/vehicle-command/ask-resources.json
+++ b/vehicle-command/ask-resources.json
@@ -14,7 +14,7 @@
         "type": "@ask-cli/lambda-deployer",
         "userConfig": {
           "awsRegion": "us-east-1\u001b",
-          "runtime": "nodejs10.x",
+          "runtime": "nodejs14.x",
           "handler": "index.handler"
         }
       }


### PR DESCRIPTION
CloudFormation templates in connected-vehicle-lab have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.